### PR TITLE
[semver:patch] Improve git_checkout

### DIFF
--- a/src/commands/git_checkout.yml
+++ b/src/commands/git_checkout.yml
@@ -1,27 +1,31 @@
 ---
 description: >
-  Download repo and checkout a specific branch.
+  Download repo and checkout a specific branch. It creates a folder with
+  same name as the repo.
   This command requires GIT_EMAIL and GIT_USERNAME to be defined in the
   CircleCI context used.
 parameters:
-  url:
-    description: Repository url
-    type: string
   branch:
     description: >
-      Branch to checkout. If not set, the script will first try to use
+      Branch to checkout. If not set, the script first tries to use
       the same branch of the current pipeline. If nothing is found,
       it uses the default base branch (master/main)
     type: string
     default: ""
   dir:
-    description: Directory where to clone the repository
+    description: >
+      Directory where to clone the repository. If not set, the script
+      uses the CIRCLE_WORKING_DIRECTORY environment variable as
+      the default directory.
     type: string
-    default: "/tmp"
+    default: ""
   merge_master:
     description: Option to merge master/main into the branch to checkout
     type: boolean
     default: true
+  url:
+    description: Repository url
+    type: string
 steps:
   - run:
       name: "Download << parameters.url >> (branch: <<parameters.branch>>)"

--- a/src/commands/git_checkout.yml
+++ b/src/commands/git_checkout.yml
@@ -28,7 +28,7 @@ parameters:
     type: string
 steps:
   - run:
-      name: "Download << parameters.url >> (branch: <<parameters.branch>>)"
+      name: "Download repo << parameters.url >>"
       environment:
         MERGE_MASTER: << parameters.merge_master >>
         REPO_BRANCH: << parameters.branch >>

--- a/src/scripts/git_checkout.sh
+++ b/src/scripts/git_checkout.sh
@@ -2,7 +2,6 @@
 
 CheckoutRepo() {
  
-  
   if [ -z $REPO_BRANCH ]; then
     if git ls-remote -h $REPO_URL | grep -q "${CIRCLE_BRANCH}"; then
       REPO_BRANCH="${CIRCLE_BRANCH}"
@@ -18,10 +17,19 @@ CheckoutRepo() {
     fi
   fi
   
+  if [ -z $REPO_DIR ]; then
+    REPO_DIR=${CIRCLE_WORKING_DIRECTORY}
+  fi
+
+
   basename=$(basename $REPO_URL)
   REPO_NAME=${basename%.*}
   
-  echo "Cloning repo $REPO_URL on branch $REPO_BRANCH"
+  echo ">> Cloning repo: "
+  echo "  >> Name: ${REPO_NAME}"
+  echo "  >> Url: ${REPO_URL}"
+  echo "  >> Branch: ${REPO_BRANCH}"
+  echo "  >> Base dir: ${REPO_DIR}"
   git clone $REPO_URL --branch $REPO_BRANCH --single-branch "${REPO_DIR}/${REPO_NAME}"
 
 


### PR DESCRIPTION
Uses CIRCLE_WORKING_DIRECTORY as the default directory to download the repo to. 