### PR TITLE
[semver:patch] fix issue with download path of git_checkout.sh

### DIFF
--- a/src/commands/git_checkout.yml
+++ b/src/commands/git_checkout.yml
@@ -15,8 +15,7 @@ parameters:
   dir:
     description: >
       Directory where to clone the repository. If not set, the script
-      uses the CIRCLE_WORKING_DIRECTORY environment variable as
-      the default directory.
+      uses "${HOME}/project" as the default directory.
     type: string
     default: ""
   merge_master:

--- a/src/scripts/git_checkout.sh
+++ b/src/scripts/git_checkout.sh
@@ -19,7 +19,11 @@ CheckoutRepo() {
   
 
   if [ -z $REPO_DIR ]; then
-    REPO_DIR="${HOME}/project"
+    if [[ "$HOME" == *"circleci"* ]]; then
+      REPO_DIR="${HOME}"
+    else
+      REPO_DIR="${HOME}/project"
+    fi
   else
     mkdir -p "${REPO_DIR}"
   fi

--- a/src/scripts/git_checkout.sh
+++ b/src/scripts/git_checkout.sh
@@ -17,10 +17,12 @@ CheckoutRepo() {
     fi
   fi
   
-  if [ -z $REPO_DIR ]; then
-    REPO_DIR=${CIRCLE_WORKING_DIRECTORY}
-  fi
 
+  if [ -z $REPO_DIR ]; then
+    REPO_DIR="${HOME}/project"
+  else
+    mkdir -p "${REPO_DIR}"
+  fi
 
   basename=$(basename $REPO_URL)
   REPO_NAME=${basename%.*}
@@ -30,8 +32,14 @@ CheckoutRepo() {
   echo "  >> Url: ${REPO_URL}"
   echo "  >> Branch: ${REPO_BRANCH}"
   echo "  >> Base dir: ${REPO_DIR}"
-  git clone $REPO_URL --branch $REPO_BRANCH --single-branch "${REPO_DIR}/${REPO_NAME}"
+  
+  cd "${REPO_DIR}"
+  git clone $REPO_URL --branch $REPO_BRANCH --single-branch "${REPO_NAME}"
 
+  TMP_REPO_NAME=${REPO_NAME//-/_}
+  echo "Adding GIT_${TMP_REPO_NAME^^}_DIR='${REPO_DIR}/${REPO_NAME}' to bash env"
+  echo "export GIT_${TMP_REPO_NAME^^}_DIR='${REPO_DIR}/${REPO_NAME}'" >> "${BASH_ENV}"
+  source ${BASH_ENV}
 
   if [ $MERGE_MASTER -eq 1 ] || [ ! -z $MERGE_MASTER ]; then
     if [ -z $GIT_EMAIL ] || [ -z $GIT_USERNAME ]; then


### PR DESCRIPTION
resolve #48 

Il comando `git_checkout.sh` creava una cartella `~/project` come sottocartella della già presente `~/project` (creata automaticamente da circleci). 
Come folder di default per il download del repo ora viene usata `$HOME/project`.

Inoltre, viene aggiunta al `BASH_ENV` una variabile contenente il path alla folder del repository. 