### PR TITLE
[semver:patch] Fix typo in cookbook_kitchen_test command

### DIFF
--- a/src/commands/cookbooks_kitchen_test.yml
+++ b/src/commands/cookbooks_kitchen_test.yml
@@ -15,7 +15,7 @@ parameters:
 steps:
   - run:
       name: Run tests
-      enviroment:
+      environment:
         PARAM_KITCHEN_SUITES: << parameters.suites >>
         PARAM_KITCHEN_CONCURRENCY: << parameters.concurrency >>
         CONVERGE_NUMBER: << parameters.converge_number >>


### PR DESCRIPTION
ref https://github.com/ClouDesire/support/issues/4313