### PR TITLE
[semver:patch] Pin docker java executor default version to latest available version

### DIFF
--- a/src/executors/docker_java.yml
+++ b/src/executors/docker_java.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   java_version:
     type: string
-    default: 8.0
+    default: "8.0"
   resource_class:
     type: string
     default: small

--- a/src/executors/docker_java.yml
+++ b/src/executors/docker_java.yml
@@ -1,11 +1,11 @@
 ---
 description: >
   This is a Java executor. The Java version is passed as a parameter.
-  Default Java version is 8.0.265, more tags here: https://circleci.com/developer/images/image/cimg/openjdk
+  Default Java version is 8.0, more tags here: https://circleci.com/developer/images/image/cimg/openjdk
 parameters:
   java_version:
     type: string
-    default: 8.0.265
+    default: 8.0
   resource_class:
     type: string
     default: small


### PR DESCRIPTION
Avoid pinning an old and maybe bugged release