### PR TITLE
[semver:patch] use `Circle-Token` header

### DIFF
--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -12,11 +12,11 @@ if [ -z "${ORG}" ]; then
   exit 1
 fi
 
-if [ -z $BRANCH ] || [ "${BRANCH}" == "" ]; then
+if [ -z "$BRANCH" ] || [ "${BRANCH}" == "" ]; then
   REPO_URL="git@github.com:${ORG}/${PROJECT_NAME}.git"
-  if git ls-remote -h $REPO_URL | grep -q "${CIRCLE_BRANCH}"; then
+  if git ls-remote -h "$REPO_URL" | grep -q "${CIRCLE_BRANCH}"; then
     BRANCH="${CIRCLE_BRANCH}"
-  elif git ls-remote -h $REPO_URL | grep -q "refs/heads/main"; then
+  elif git ls-remote -h "$REPO_URL" | grep -q "refs/heads/main"; then
     BRANCH="main"
   else
     BRANCH="master"
@@ -40,6 +40,7 @@ echo -e "\n"
 
 curl \
   --header "Content-Type: application/json" \
+  --header "Circle-Token: ${CIRCLECI_TOKEN}" \
   --data "${json_data}" \
   --request POST \
-  https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline?circle-token="${CIRCLECI_TOKEN}"
+  "https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline"

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -48,7 +48,7 @@ curl \
   "${PIPELINE_API_URL}" -o "${CIRCLE_RESPONSE_OUTPUT_PATH}"
 
 cat "${CIRCLE_RESPONSE_OUTPUT_PATH}"
-PIPELINE_NUMBER=$(jq --raw-output .number "${CIRCLE_RESPONSE_OUTPUT_PATH}")
+PIPELINE_NUMBER=$(jq --raw-output '.number // empty' "${CIRCLE_RESPONSE_OUTPUT_PATH}")
 
 if [ -z "${PIPELINE_NUMBER}" ]; then
   echo "Something went wrong triggering ${PROJECT_NAME} pipeline"

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -39,16 +39,16 @@ echo ">> Parameters: ${PARAMETERS}"
 echo ">> Url: ${PIPELINE_API_URL}"
 echo -e "\n"
 
-PIPELINE_ID=$(curl \
+PIPELINE_NUMBER=$(curl \
   --header "Content-Type: application/json" \
   --header "Circle-Token: ${CIRCLECI_TOKEN}" \
   --data "${json_data}" \
   --request POST \
-  "${PIPELINE_API_URL}" | jq --raw-output '.id')
+  "${PIPELINE_API_URL}" | jq --raw-output '.number')
 
-if [ -z "${PIPELINE_ID}" ]; then
+if [ -z "${PIPELINE_NUMBER}" ]; then
   echo "Something went wrong triggering ${PROJECT_NAME} pipeline"
   exit 1
+else
+  echo "Triggered ${PROJECT_NAME} pipeline ${PIPELINE_NUMBER}"
 fi
-
-

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -51,8 +51,8 @@ cat "${CIRCLE_RESPONSE_OUTPUT_PATH}"
 PIPELINE_NUMBER=$(jq --raw-output '.number // empty' "${CIRCLE_RESPONSE_OUTPUT_PATH}")
 
 if [ -z "${PIPELINE_NUMBER}" ]; then
-  echo "Something went wrong triggering ${PROJECT_NAME} pipeline"
+  echo -e "\nSomething went wrong triggering ${PROJECT_NAME} pipeline"
   exit 1
 else
-  echo "Triggered ${PROJECT_NAME} pipeline ${PIPELINE_NUMBER}"
+  echo -e "\nTriggered ${PROJECT_NAME} pipeline ${PIPELINE_NUMBER}"
 fi

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -30,7 +30,7 @@ else
 fi
 
 PIPELINE_API_URL="https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline"
-CIRCLE_RESPONSE_OUTPUT_PATH="circleci_trigger_response.json"
+CIRCLE_RESPONSE_OUTPUT_PATH="circleci_trigger_response_${PROJECT_NAME}.json"
 
 echo "Trigger info: "
 echo ">> Org: ${ORG}"

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -29,7 +29,6 @@ else
   json_data='{ "parameters": '${PARAMETERS}', "branch": "'${BRANCH}'"}'
 fi
 
-
 echo "Trigger info: "
 echo ">> Org: ${ORG}"
 echo ">> Project: ${PROJECT_NAME}"
@@ -38,9 +37,16 @@ echo ">> Parameters: ${PARAMETERS}"
 echo ">> Url: https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline?circle-token=${CIRCLECI_TOKEN}"
 echo -e "\n"
 
-curl \
+PIPELINE_ID=$(curl \
   --header "Content-Type: application/json" \
   --header "Circle-Token: ${CIRCLECI_TOKEN}" \
   --data "${json_data}" \
   --request POST \
-  "https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline"
+  "https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline" | jq --raw-output '.id')
+
+if [ -z "${PIPELINE_ID}" ]; then
+  echo "Something went wrong triggering ${PROJECT_NAME} pipeline"
+  exit 1
+fi
+
+

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -29,12 +29,14 @@ else
   json_data='{ "parameters": '${PARAMETERS}', "branch": "'${BRANCH}'"}'
 fi
 
+PIPELINE_API_URL="https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline"
+
 echo "Trigger info: "
 echo ">> Org: ${ORG}"
 echo ">> Project: ${PROJECT_NAME}"
 echo ">> Branch: ${BRANCH}"
 echo ">> Parameters: ${PARAMETERS}"
-echo ">> Url: https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline?circle-token=${CIRCLECI_TOKEN}"
+echo ">> Url: ${PIPELINE_API_URL}"
 echo -e "\n"
 
 PIPELINE_ID=$(curl \
@@ -42,7 +44,7 @@ PIPELINE_ID=$(curl \
   --header "Circle-Token: ${CIRCLECI_TOKEN}" \
   --data "${json_data}" \
   --request POST \
-  "https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline" | jq --raw-output '.id')
+  "${PIPELINE_API_URL}" | jq --raw-output '.id')
 
 if [ -z "${PIPELINE_ID}" ]; then
   echo "Something went wrong triggering ${PROJECT_NAME} pipeline"

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -30,6 +30,7 @@ else
 fi
 
 PIPELINE_API_URL="https://circleci.com/api/v2/project/gh/${ORG}/${PROJECT_NAME}/pipeline"
+CIRCLE_RESPONSE_OUTPUT_PATH="circleci_trigger_response.json"
 
 echo "Trigger info: "
 echo ">> Org: ${ORG}"
@@ -39,12 +40,15 @@ echo ">> Parameters: ${PARAMETERS}"
 echo ">> Url: ${PIPELINE_API_URL}"
 echo -e "\n"
 
-PIPELINE_NUMBER=$(curl \
+curl \
   --header "Content-Type: application/json" \
   --header "Circle-Token: ${CIRCLECI_TOKEN}" \
   --data "${json_data}" \
   --request POST \
-  "${PIPELINE_API_URL}" | jq --raw-output '.number')
+  "${PIPELINE_API_URL}" -o "${CIRCLE_RESPONSE_OUTPUT_PATH}"
+
+cat "${CIRCLE_RESPONSE_OUTPUT_PATH}"
+PIPELINE_NUMBER=$(jq .number "${CIRCLE_RESPONSE_OUTPUT_PATH}")
 
 if [ -z "${PIPELINE_NUMBER}" ]; then
   echo "Something went wrong triggering ${PROJECT_NAME} pipeline"

--- a/src/scripts/circleci_trigger_pipeline.sh
+++ b/src/scripts/circleci_trigger_pipeline.sh
@@ -48,7 +48,7 @@ curl \
   "${PIPELINE_API_URL}" -o "${CIRCLE_RESPONSE_OUTPUT_PATH}"
 
 cat "${CIRCLE_RESPONSE_OUTPUT_PATH}"
-PIPELINE_NUMBER=$(jq .number "${CIRCLE_RESPONSE_OUTPUT_PATH}")
+PIPELINE_NUMBER=$(jq --raw-output .number "${CIRCLE_RESPONSE_OUTPUT_PATH}")
 
 if [ -z "${PIPELINE_NUMBER}" ]; then
   echo "Something went wrong triggering ${PROJECT_NAME} pipeline"


### PR DESCRIPTION
ref https://github.com/ClouDesire/support/issues/5963

The `circle-token` query parameter is now deprecated https://circleci.com/docs/api/v2/#section/Authentication

Usando HTTP Header:
```
curl \
  --header "Content-Type: application/json" \
  --header "Circle-Token: ${CIRCLECI_TOKEN}" \
  --data '{ "branch": "master" }' \
  --request POST \
  "https://circleci.com/api/v2/project/gh/ClouDesire/cookbook-cd-docker/pipeline"
{
  "number" : 802,
  "state" : "pending",
  "id" : "b6f70bd2-b855-49df-9301-522426c8f6d2",
  "created_at" : "2021-11-30T09:32:34.017Z"
}
```