### PR TITLE
[semver:major] remove context common-circleci for publish workflow

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -30,4 +30,8 @@ Once approved, the development version of the orb will publish and the _trigger-
 
 The second and final workflow is manually triggered by the _trigger-integration-tests-workflow_ job. In this run, the development version of the orb that was just published will be imported, and the integration tests will run.
 
-When running on the `master` branch (after merging to `master`), the workflow will additionally publish your new production orb.
+When running on the `master` branch (after merging to `master`), the workflow will additionally publish your new production orb.  
+
+The `orb-tools/dev-promote-prod-from-commit-subject` job uses the `CIRCLE_TOKEN` environment variable by default to
+publish the new orb version.
+The owner of the `CIRCLECI_TOKEN` must be the owner of the github organization associated with the circleci account.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,6 @@ workflows:
     jobs:
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: cloudesire/common
-          context: common-circleci
           add-pr-comment: false
           fail-if-semver-not-indicated: true
           publish-version-tag: true


### PR DESCRIPTION
Ho inserito un mio CIRCLECI_TOKEN come variabile d'ambiente del progetto per poter fare la `publish` di un orb, perché solo un `owner` dell'org su `github` può fare publish di una versione `prod` dell'`orb`