### PR TITLE
chore: upgrade yarn_release node image to 18.12.1

### DIFF
--- a/src/jobs/yarn_release.yml
+++ b/src/jobs/yarn_release.yml
@@ -15,7 +15,7 @@ parameters:
     type: string
     default: "."
 docker:
-  - image: cimg/node:8.17
+  - image: cimg/node:18.12.1
 steps:
   - attach_workspace:
       at: << parameters.workspace >>


### PR DESCRIPTION
https://github.com/ClouDesire/angular-cloudesire-common/pull/306