### PR TITLE
fix: change npmrc token path

### DIFF
--- a/src/scripts/yarn_release.sh
+++ b/src/scripts/yarn_release.sh
@@ -7,9 +7,9 @@ YarnRelease() {
   echo "Setting up .npmrc"
   npm config set "@cloudesire:registry" "$NPM_REGISTRY"
   
-  NPM_REGISTRY_HOSTNAME="${NPM_REGISTRY##*://}"
-  NPM_REGISTRY_HOSTNAME="${NPM_REGISTRY_HOSTNAME%'/'}"
-  npm config set //$NPM_REGISTRY_HOSTNAME/:_authToken=$NPM_TOKEN
+  NPM_REGISTRY_REPO_PATH="${NPM_REGISTRY##*://}"
+  NPM_REGISTRY_REPO_PATH="${NPM_REGISTRY_REPO_PATH%/*}"
+  npm config set //$NPM_REGISTRY_REPO_PATH/:_authToken=$NPM_TOKEN
   
   echo "Releasing $RELEASE_VERSION"
   npm publish --registry $NPM_REGISTRY


### PR DESCRIPTION
così dovrebbe salvarlo come

    //nexus.cloudesire.com/repository/:_authToken=NpmToken.asdffdsa
    @cloudesire:registry=https://nexus.cloudesire.com/repository/cloudesire-npm